### PR TITLE
feat(#18): 예매 요청 시 예매 데이터 생성 & 결제 데이터 생성 요청 구현

### DIFF
--- a/src/main/java/com/bs/booking/clients/PaymentServiceClient.java
+++ b/src/main/java/com/bs/booking/clients/PaymentServiceClient.java
@@ -1,0 +1,43 @@
+package com.bs.booking.clients;
+
+import com.bs.booking.dtos.PaymentCreateDto;
+import com.bs.booking.dtos.common.ResponseDto;
+import com.bs.booking.exceptions.PaymentServiceResponseException;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class PaymentServiceClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${external.service.base.url}")
+    private String externalServiceBaseUrl;
+
+    private String baseUrl;
+
+    @PostConstruct
+    public void init() {
+        baseUrl = externalServiceBaseUrl + "/payments";
+    }
+
+    public ResponseDto createPayment(PaymentCreateDto createDto) {
+        log.info("Sending request to create payment with values: {}", createDto);
+
+        ResponseEntity<ResponseDto> response = restTemplate.postForEntity(baseUrl, createDto,
+            ResponseDto.class);
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            log.error("Failed to create payment with values: {}", createDto);
+            throw new PaymentServiceResponseException("결제 생성에 실패하였습니다");
+        }
+        log.info("Successfully created payment");
+        return response.getBody();
+    }
+}

--- a/src/main/java/com/bs/booking/configs/RestTemplateConfig.java
+++ b/src/main/java/com/bs/booking/configs/RestTemplateConfig.java
@@ -1,0 +1,19 @@
+package com.bs.booking.configs;
+
+import java.time.Duration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder
+            .setConnectTimeout(Duration.ofSeconds(10))
+            .setReadTimeout(Duration.ofSeconds(10))
+            .build();
+    }
+}

--- a/src/main/java/com/bs/booking/controllers/ReservationController.java
+++ b/src/main/java/com/bs/booking/controllers/ReservationController.java
@@ -32,11 +32,11 @@ public class ReservationController {
         return new ResponseDto("success", "Reservations retrieved successfully", reservations);
     }
 
-    @PostMapping
+    @PostMapping("/{id}")
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseDto createReservation(
+    public ResponseDto createReservation(@PathVariable long id,
         @Valid @RequestBody ReservationCreateDto valuesForCreate) {
-        ReservationResponseDto created = reservationService.createReservation(valuesForCreate);
+        ReservationResponseDto created = reservationService.createReservation(id, valuesForCreate);
         return new ResponseDto("success", "Reservation created successfully", created);
     }
 

--- a/src/main/java/com/bs/booking/dtos/PaymentCreateDto.java
+++ b/src/main/java/com/bs/booking/dtos/PaymentCreateDto.java
@@ -12,7 +12,10 @@ import lombok.ToString;
 @NoArgsConstructor
 @Getter
 @Setter
-public class ReservationCreateDto {
+public class PaymentCreateDto {
+
+    @NotNull(message = "예매 id는 필수입니다")
+    private Long reservationId;
 
     @NotNull(message = "사용자 id는 필수입니다")
     private String userId;

--- a/src/main/java/com/bs/booking/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/bs/booking/exceptions/GlobalExceptionHandler.java
@@ -32,7 +32,7 @@ public class GlobalExceptionHandler {
             .map(error -> error.getField() + ": " + error.getDefaultMessage())
             .collect(Collectors.joining(", "));
         log.error(errorMessage, e);
-        return ResponseDto.builder().status("failed").message(errorMessage).build();
+        return ResponseDto.builder().status("failed").message("잘못된 요청 값입니다: " + errorMessage).build();
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/bs/booking/exceptions/PaymentServiceResponseException.java
+++ b/src/main/java/com/bs/booking/exceptions/PaymentServiceResponseException.java
@@ -1,0 +1,10 @@
+package com.bs.booking.exceptions;
+
+public class PaymentServiceResponseException extends IllegalArgumentException {
+
+    public static final String MESSAGE_FORMAT = "결제 서비스로부터 예기치 않은 응답 발생 : %s";
+
+    public PaymentServiceResponseException(String msg) {
+        super(String.format(MESSAGE_FORMAT, msg));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,6 @@ springdoc.api-docs.path=/api-docs
 logging.level.root=INFO
 logging.level.org.springframework.web=INFO
 logging.level.com.bs.booking=DEBUG
+
+# services url
+external.service.base.url=https://99hj5u45wf.execute-api.ap-northeast-2.amazonaws.com/api

--- a/src/test/java/com/bs/booking/clients/PaymentServiceClientTest.java
+++ b/src/test/java/com/bs/booking/clients/PaymentServiceClientTest.java
@@ -1,0 +1,80 @@
+package com.bs.booking.clients;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bs.booking.dtos.PaymentCreateDto;
+import com.bs.booking.dtos.common.ResponseDto;
+import com.bs.booking.exceptions.PaymentServiceResponseException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestTemplate;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceClientTest {
+
+    @InjectMocks
+    private PaymentServiceClient paymentServiceClient;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @BeforeEach
+    void setUp() {
+        paymentServiceClient.init();
+    }
+
+    @DisplayName("[success] 결제 데이터 생성 요청")
+    @Test
+    void createPayment_success() {
+        // given
+        PaymentCreateDto createDto = new PaymentCreateDto(1L, "user1");
+        ResponseDto mockResponse = new ResponseDto("success", "", null);
+
+        ResponseEntity<ResponseDto> response = new ResponseEntity<>(mockResponse, HttpStatus.OK);
+
+        when(restTemplate.postForEntity(anyString(), any(PaymentCreateDto.class),
+            eq(ResponseDto.class))).thenReturn(response);
+
+        // when
+        ResponseDto actualResponse = paymentServiceClient.createPayment(createDto);
+
+        // then
+        verify(restTemplate, times(1))
+            .postForEntity(anyString(), any(PaymentCreateDto.class), eq(ResponseDto.class));
+        assertThat(actualResponse.getStatus()).isEqualTo("success");
+    }
+
+    @DisplayName("[fail] 결제 데이터 생성 요청")
+    @Test
+    void createPayment_fail() {
+        // given
+        PaymentCreateDto createDto = new PaymentCreateDto(1L, "user1");
+        ResponseDto mockResponse = new ResponseDto("fail", "", null);
+
+        ResponseEntity<ResponseDto> response = new ResponseEntity<>(mockResponse,
+            HttpStatus.BAD_REQUEST);
+
+        when(restTemplate.postForEntity(anyString(), any(PaymentCreateDto.class),
+            eq(ResponseDto.class))).thenReturn(response);
+
+        // when, then
+        assertThrows(PaymentServiceResponseException.class,
+            () -> paymentServiceClient.createPayment(createDto));
+    }
+}

--- a/src/test/java/com/bs/booking/controllers/ReservationControllerTest.java
+++ b/src/test/java/com/bs/booking/controllers/ReservationControllerTest.java
@@ -54,8 +54,7 @@ class ReservationControllerTest {
 
         when(reservationService.getAllReservation()).thenReturn(reservations);
         // when, then
-        mockMvc.perform(get(BASE_URL))
-            .andExpect(status().isOk())
+        mockMvc.perform(get(BASE_URL)).andExpect(status().isOk())
             .andExpect(jsonPath("$.data", hasSize(1)))
             .andExpect(jsonPath("$.data[0].status", is(expectStatus.toString())));
     }
@@ -65,14 +64,14 @@ class ReservationControllerTest {
     void createReservation() throws Exception {
         // given
         ReservationStatus expectStatus = ReservationStatus.PENDING;
-        String valToCreate = "{\"sessionSeatId\":1,\"userId\":1}";
-        ReservationResponseDto reservation = ReservationResponseDto
-            .builder().status(expectStatus).build();
+        String valToCreate = "{\"userId\":1}";
+        ReservationResponseDto reservation = ReservationResponseDto.builder().status(expectStatus)
+            .build();
 
-        when(reservationService.createReservation(any(ReservationCreateDto.class))).thenReturn(
-            reservation);
+        when(reservationService.createReservation(anyLong(),
+            any(ReservationCreateDto.class))).thenReturn(reservation);
         // when, then
-        mockMvc.perform(post(BASE_URL)
+        mockMvc.perform(post(BASE_URL + "/1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(valToCreate))
             .andExpect(status().isCreated())
@@ -83,12 +82,10 @@ class ReservationControllerTest {
     @Test
     void createReservation_whenNotEnoughRequestBody_shouldThrowsException() throws Exception {
         // given
-        String valToCreate = "{\"userId\":1}";
+        String valToCreate = "{}";
 
         // when, then
-        mockMvc.perform(post(BASE_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(valToCreate))
+        mockMvc.perform(post(BASE_URL+"/1").contentType(MediaType.APPLICATION_JSON).content(valToCreate))
             .andExpect(status().isBadRequest());
     }
 
@@ -98,14 +95,13 @@ class ReservationControllerTest {
         // given
         ReservationStatus expectStatus = ReservationStatus.CANCEL;
         String valToUpdate = "{\"status\":\"" + expectStatus.name() + "\"}";
-        ReservationResponseDto reservation = ReservationResponseDto
-            .builder().status(expectStatus).build();
-        when(reservationService.updateStatus(anyLong(), any(ReservationStatus.class)))
-            .thenReturn(reservation);
+        ReservationResponseDto reservation = ReservationResponseDto.builder().status(expectStatus)
+            .build();
+        when(reservationService.updateStatus(anyLong(), any(ReservationStatus.class))).thenReturn(
+            reservation);
         // when, then
-        mockMvc.perform(put(BASE_URL+"/1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(valToUpdate))
+        mockMvc.perform(
+                put(BASE_URL + "/1").contentType(MediaType.APPLICATION_JSON).content(valToUpdate))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.status", is(expectStatus.toString())));
     }
@@ -117,11 +113,9 @@ class ReservationControllerTest {
         String valToUpdate = "{\"noStatus\":\"fd\"}";
 
         // when, then
-        mockMvc.perform(put(BASE_URL+"/1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(valToUpdate))
-            .andExpect(status().isBadRequest())
-            .andExpect(result -> assertTrue(
+        mockMvc.perform(
+                put(BASE_URL + "/1").contentType(MediaType.APPLICATION_JSON).content(valToUpdate))
+            .andExpect(status().isBadRequest()).andExpect(result -> assertTrue(
                 result.getResolvedException() instanceof MethodArgumentNotValidException));
     }
 
@@ -132,11 +126,9 @@ class ReservationControllerTest {
         String valToUpdate = "{\"status\":\"fd\"}";
 
         // when, then
-        mockMvc.perform(put(BASE_URL+"/1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(valToUpdate))
-            .andExpect(status().isBadRequest())
-            .andExpect(result -> assertTrue(
+        mockMvc.perform(
+                put(BASE_URL + "/1").contentType(MediaType.APPLICATION_JSON).content(valToUpdate))
+            .andExpect(status().isBadRequest()).andExpect(result -> assertTrue(
                 result.getResolvedException() instanceof HttpMessageConversionException));
     }
 }

--- a/src/test/java/com/bs/booking/repositories/ReservationRepositoryTest.java
+++ b/src/test/java/com/bs/booking/repositories/ReservationRepositoryTest.java
@@ -35,7 +35,7 @@ class ReservationRepositoryTest {
     void setUp() {
         sessionSeat = new SessionSeat(1L, 1L, 1L);
         testEntityManager.persistAndFlush(sessionSeat);
-        ReservationCreateDto createDto = new ReservationCreateDto(sessionSeat.getId(), "testUser");
+        ReservationCreateDto createDto = new ReservationCreateDto("testUser");
         Reservation reservation1 = new Reservation(sessionSeat, createDto.getUserId());
         Reservation reservation2 = new Reservation(sessionSeat, createDto.getUserId());
         Reservation reservation3 = new Reservation(sessionSeat, createDto.getUserId());

--- a/src/test/java/com/bs/booking/services/ReservationServiceTest.java
+++ b/src/test/java/com/bs/booking/services/ReservationServiceTest.java
@@ -7,8 +7,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.bs.booking.clients.PaymentServiceClient;
+import com.bs.booking.dtos.PaymentCreateDto;
 import com.bs.booking.dtos.ReservationCreateDto;
 import com.bs.booking.dtos.ReservationResponseDto;
+import com.bs.booking.dtos.common.ResponseDto;
 import com.bs.booking.enums.ReservationStatus;
 import com.bs.booking.models.Reservation;
 import com.bs.booking.models.SessionSeat;
@@ -40,6 +43,9 @@ class ReservationServiceTest {
     @Mock
     ReservationMapper reservationMapper;
 
+    @Mock
+    PaymentServiceClient paymentServiceClient;
+
     @DisplayName("모든 예약정보 가져오기")
     @Test
     void getAllReservation() {
@@ -64,7 +70,7 @@ class ReservationServiceTest {
     @Test
     void createReservation() {
         // given
-        ReservationCreateDto valuesForCreate = new ReservationCreateDto(1L, "testUser");
+        ReservationCreateDto valuesForCreate = new ReservationCreateDto("testUser");
         SessionSeat sessionSeat = new SessionSeat();
         Reservation reservation = new Reservation(sessionSeat, valuesForCreate.getUserId());
         ReservationResponseDto expectedReservation = new ReservationResponseDto();
@@ -77,8 +83,11 @@ class ReservationServiceTest {
         when(reservationRepository.save(any(Reservation.class))).thenReturn(reservation);
         when(reservationMapper.toReservationResponseDto(any(Reservation.class))).thenReturn(
             expectedReservation);
+        when(paymentServiceClient.createPayment(any(PaymentCreateDto.class))).thenReturn(
+            new ResponseDto());
+
         // when
-        ReservationResponseDto created = reservationService.createReservation(valuesForCreate);
+        ReservationResponseDto created = reservationService.createReservation(1L, valuesForCreate);
         // then
         assertThat(created).isNotNull().isEqualTo(expectedReservation);
         verify(reservationRepository, times(1)).save(any(Reservation.class));

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -10,3 +10,6 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.id.new_generator_mappings = true
+
+# services url
+external.service.base.url=http://localhost:8080


### PR DESCRIPTION
- [x]  예매 데이터 여부 확인 구현
- [x]  예매 데이터 생성 구현
- [x]  다중 동시 요청 상황에서 하나의 예매 데이터만 생성하도록 구현
- [x]  다중 동시 요청 상황 테스트
- [x]  결제 서비스에 결제 데이터 생성 요청 구현